### PR TITLE
Schema Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "camelcase": "^5.3.1",
     "graphql-request": "^1.8.2",
-    "nanoid": "^2.1.7",
+    "nanoid": "^2.1.9",
     "prettyjson": "^1.2.1"
   },
   "devDependencies": {
@@ -38,7 +38,7 @@
     "babel-eslint": "10.0.3",
     "eslint": "6.8.0",
     "eslint-config-standard": "14.1.0",
-    "eslint-config-travisreynolds-node": "1.1.2",
+    "eslint-config-travisreynolds-node": "1.1.3",
     "eslint-plugin-html": "6.0.0",
     "eslint-plugin-import": "2.20.0",
     "eslint-plugin-node": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,10 +1470,10 @@ eslint-config-standard@14.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz#b23da2b76fe5a2eba668374f246454e7058f15d4"
   integrity sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==
 
-eslint-config-travisreynolds-node@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-travisreynolds-node/-/eslint-config-travisreynolds-node-1.1.2.tgz#760a52ceedb1bc124167525e9bd9aa328c25d116"
-  integrity sha512-e8PJNRrkSSOpeGym00I/RiEi7g8xZw5uLwIxJ0e9CdO1UpeV/TbwZiRcjM39VTssjehdd6jIhDiYVdBsXOPcmw==
+eslint-config-travisreynolds-node@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-travisreynolds-node/-/eslint-config-travisreynolds-node-1.1.3.tgz#064ef905958f10419daa836809bc269a23d9f64e"
+  integrity sha512-I7tVi2Ow2ubJr7MgrfROI4dfT7IrNjaXVXD/cApT2OwJUOPM/cZ2kTNEX7+nCRghn0anLoR0pza/AlLAEbQ1Fg==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -2461,10 +2461,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanoid@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.7.tgz#d775e3e7c6470bbaaae3da9a647a80e228e0abf7"
-  integrity sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ==
+nanoid@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.9.tgz#edc71de7b16fc367bbb447c7a638ccebe07a17a1"
+  integrity sha512-J2X7aUpdmTlkAuSe9WaQ5DsTZZPW1r/zmEWKsGhbADO6Gm9FMd2ZzJ8NhsmP4OtA9oFhXfxNqPlreHEDOGB4sg==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
This PR will add the Shopify Storefront types to the Gridsome GraphQL schema - this means that, for instance, it will add the `Collection` type to the schema, even if there currently no collections in Shopify. So if a site (for example the `gridsome-starter-shopify`) relies on a type in it's page queries, and no data of that type yet exists in the Shopify store, the site build will not break - the query result will just be null.