### PR TITLE
Update to Shopify API client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ import { COLLECTION_QUERY } from './queries'
  * Create a Shopify Storefront GraphQL client for the provided name and token.
  */
 export const createClient = ({ storeUrl, storefrontToken, timeout }) => got.extend({
-  prefixUrl: `${storeUrl}/api/2020-10`,
+  prefixUrl: `${storeUrl}/api/2022-01`,
   headers: {
     'X-Shopify-Storefront-Access-Token': storefrontToken
   },


### PR DESCRIPTION
Hey Travis! Hope you have been doing well! 

I have a couple little Shopify stores still using this repo (I am slowly moving them over to Nuxt haha) and it would be great to get the client updated to 2022-01 which doesn't conflict with any current queries you have in this project. 

The 2022-07 version has more significant changes within the given queries such as dropping the `url` and some other deprecated tags. The `PRODUCTS_QUERY` also has some changes with the how the metafields are setup. 

However, the 2022-01 does not cause any conflicts... at least when I was testing it out:)